### PR TITLE
Actually sync identities

### DIFF
--- a/postfixadmin_user_identities.php
+++ b/postfixadmin_user_identities.php
@@ -48,17 +48,17 @@ class postfixadmin_user_identities extends rcube_plugin
 
         $qh = $this->db->query($qrystr);
         $result = $this->db->fetch_array($qh);
-        if ($result !== FALSE)
-        {
-            $hidden_domains = $this->rc->config->get('postfixadmin_user_identities_hide_domains');
 
-            // Set full user name
+        $email_list = array();
+        $hidden_domains = $this->rc->config->get('postfixadmin_user_identities_hide_domains');
+        while ($result !== FALSE)
+        {
             $args['user_name'] = $result[0];
-            
-            $email_list = array();
-            
             $email_list[] = array($result[1], $result[2]);
-            
+            $result = $this->db->fetch_array($qh);
+        }
+        if (count($email_list) > 0)
+        {
             // Fetch alias domains
             $t_adom = $this->db->quote_identifier($this->rc->config->get('postfixadmin_user_identities_table_aliasdomain'));
             $c_adom_source = $t_adom . '.' . $this->db->quote_identifier($this->rc->config->get('postfixadmin_user_identities_col_aliasdomain'));


### PR DESCRIPTION
Tried it, your version did not sync anything for me. Using postfixadmin 3.2.1 and roundcube 1.4.2, if that should matter (I doubt it)

Debugged, found that the first query got treated as if it only has one result, ever. Adjusted to make it go over all rows in result and I got the load of identities created in roundcube that I expected to be there.

No idea if this is the correct/best way, PHP isn't mine, but it made if work for me on 2 servers and 6 accounts I checked.